### PR TITLE
fix reading of realtime data from release 1.5.2, test_values have been removed, but are still referenced in assignment

### DIFF
--- a/custom_components/saj_modbus/hub.py
+++ b/custom_components/saj_modbus/hub.py
@@ -250,11 +250,7 @@ class SAJModbusHub(DataUpdateCoordinator[dict]):
             if key == "skip":
                 decoder.skip_bytes(factor)
             else:
-                # Setze Testwerte für faultMsg0, faultMsg1 und faultMsg2
-                if key in test_values:
-                    decoded_value = test_values[key]
-                else:
-                    decoded_value = getattr(decoder, method)()
+                decoded_value = getattr(decoder, method)()
                 
                 if is_temp:
                     data[key] = round(decoded_value * factor, 1)


### PR DESCRIPTION
remove assigning test_values upon reading modbus realtime data, test_values has been removed with release 1.5.2