### PR TITLE
Reg8300

### DIFF
--- a/custom_components/saj_modbus/const.py
+++ b/custom_components/saj_modbus/const.py
@@ -194,6 +194,19 @@ information_sensors = [
     {"name": "Direction Battery", "key": "directionBattery", "icon": "arrow-all"},
     {"name": "Direction Grid", "key": "directionGrid", "icon": "arrow-all"},
     {"name": "Direction Ouput", "key": "directionOutput", "icon": "arrow-all"},
+    {"name": "PassiveCharge Enable", "key": "passchargeena", "icon": "information-outline"},
+    {"name": "PassiveGridCharge Power", "key": "passgridchargepow", "icon": "information-outline"},
+    {"name": "PassiveGridDisCharge Power", "key": "passgriddischargepow", "icon": "information-outline"},
+    {"name": "PassiveBatteryCharge Power", "key": "passbatchargepow", "icon": "information-outline"},
+    {"name": "PassiveBatteryDisCharge Power", "key": "passbatdischargepow", "icon": "information-outline"},
+    {"name": "BatteryOnGridDisCharge Depth", "key": "batongriddisdepth", "icon": "information-outline"},
+    {"name": "BatteryOffGridDisCharge Depth", "key": "batoffgriddisdepth", "icon": "information-outline"},
+    {"name": "BatteryCharge Depth", "key": "batchargedepth", "icon": "information-outline"},
+    {"name": "AppMode", "key": "appmode", "icon": "information-outline"},
+    {"name": "BatteryCharge Power", "key": "batchargepow", "icon": "information-outline"},
+    {"name": "BatteryDisCharge Power", "key": "batdischargepow", "icon": "information-outline"},
+    {"name": "GridCharge Power", "key": "gridchargepow", "icon": "information-outline"},
+    {"name": "GridDisCharge Power", "key": "griddischargepow", "icon": "information-outline"},
 ]
 
 energy_sensors = [

--- a/custom_components/saj_modbus/const.py
+++ b/custom_components/saj_modbus/const.py
@@ -207,6 +207,13 @@ information_sensors = [
     {"name": "BatteryDisCharge Power", "key": "batdischargepow", "icon": "information-outline"},
     {"name": "GridCharge Power", "key": "gridchargepow", "icon": "information-outline"},
     {"name": "GridDisCharge Power", "key": "griddischargepow", "icon": "information-outline"},
+    {"name": "ekd 8300 AppMode", "key": "ekd_8300", "icon": "information-outline"},
+    {"name": "ekd 8301 -", "key": "ekd_8301", "icon": "information-outline"},
+    {"name": "ekd 8302 ChargePower", "key": "ekd_8302", "icon": "information-outline"},
+    {"name": "ekd 8303 ChargePower", "key": "ekd_8303", "icon": "information-outline"},
+    {"name": "ekd 8304 -", "key": "ekd_8304", "icon": "information-outline"},
+    {"name": "ekd 8305 max1", "key": "ekd_8305", "icon": "information-outline"},
+    {"name": "ekd 8306 max2", "key": "ekd_8306", "icon": "information-outline"},
 ]
 
 energy_sensors = [

--- a/custom_components/saj_modbus/hub.py
+++ b/custom_components/saj_modbus/hub.py
@@ -186,7 +186,8 @@ class SAJModbusHub(DataUpdateCoordinator[Dict[str, Any]]):
                 self.read_additional_modbus_data_2_part_1,
                 self.read_additional_modbus_data_2_part_2,
                 self.read_additional_modbus_data_3,
-		self.read_charging_modbus_data_1
+		self.read_charging_modbus_data_1,
+		self.read_charging_modbus_data_2
         ]
 
         combined_data = {**self.inverter_data}

--- a/custom_components/saj_modbus/hub.py
+++ b/custom_components/saj_modbus/hub.py
@@ -185,7 +185,8 @@ class SAJModbusHub(DataUpdateCoordinator[Dict[str, Any]]):
                 self.read_additional_modbus_data_1_part_2,
                 self.read_additional_modbus_data_2_part_1,
                 self.read_additional_modbus_data_2_part_2,
-                self.read_additional_modbus_data_3
+                self.read_additional_modbus_data_3,
+		self.read_charging_modbus_data_1
         ]
 
         combined_data = {**self.inverter_data}
@@ -414,3 +415,30 @@ class SAJModbusHub(DataUpdateCoordinator[Dict[str, Any]]):
         ]
         decode_instructions = [(key, "decode_32bit_uint", 0.01) for key in data_keys]
         return await self._read_modbus_data(16711, 48, decode_instructions, 'additional_data_3')
+
+    async def read_charging_modbus_data_1(self) -> Dict[str, Any]:
+        """Reads charging-related data (Set 1)."""
+
+        decode_instructions_charging_part_1 = [
+            ("passchargeena", "decode_16bit_uint"),      
+            ("passgridchargepow", "decode_16bit_uint", 0.001),               
+            ("passgriddischargepow", "decode_16bit_uint", 0.001),               
+            ("passbatchargepow", "decode_16bit_uint", 0.001),               
+            ("passbatdischargepow", "decode_16bit_uint", 0.001),               
+            (None, "skip_bytes", 18),                  
+            ("batongriddisdepth", "decode_16bit_uint"),               
+            ("batoffgriddisdepth", "decode_16bit_uint"),               
+            ("batchargedepth", "decode_16bit_uint"),               
+            ("appmode", "decode_16bit_uint"),               
+            (None, "skip_bytes", 10),                  
+            ("batchargepow", "decode_16bit_uint", 0.001),               
+            ("batdischargepow", "decode_16bit_uint", 0.001),               
+            ("gridchargepow", "decode_16bit_uint", 0.001),               
+            ("griddischargepow", "decode_16bit_uint", 0.001),               
+        ]
+
+        return await self._read_modbus_data(
+            13878, 27, decode_instructions_charging_part_1, 'charging_data_1',
+            default_decoder="decode_16bit_uint", default_factor=1
+        )
+

--- a/custom_components/saj_modbus/hub.py
+++ b/custom_components/saj_modbus/hub.py
@@ -442,3 +442,20 @@ class SAJModbusHub(DataUpdateCoordinator[Dict[str, Any]]):
             default_decoder="decode_16bit_uint", default_factor=1
         )
 
+    async def read_charging_modbus_data_2(self) -> Dict[str, Any]:
+        """Reads charging-related data (Set 2)."""
+
+        decode_instructions_charging_part_2 = [
+            ("ekd_8300", "decode_16bit_uint"),      
+            ("ekd_8301", "decode_16bit_uint"),      
+            ("ekd_8302", "decode_16bit_uint"),      
+            ("ekd_8303", "decode_16bit_uint"),      
+            ("ekd_8304", "decode_16bit_uint"),      
+            ("ekd_8305", "decode_16bit_uint"),      
+            ("ekd_8306", "decode_16bit_uint"),      
+        ]
+
+        return await self._read_modbus_data(
+            33536, 7, decode_instructions_charging_part_2, 'charging_data_2',
+            default_decoder="decode_16bit_uint", default_factor=1
+        )


### PR DESCRIPTION
simple addition to monitor official writable registers with possible application of grid charging, and undocumented registers 8300H-8306H used by Energiekonzepte Deutschland (ekd) supplied energy manager Ampere.IQ (rebranded kiwigrid VoyagerX)

Just needed for research, ATM no vital use.
DO NOT COMMIT! 