### PR TITLE
Reduce default default visible registers for external batteries, combine 2 16bit registers into 1 32bit for 4 (external) battery packs

### DIFF
--- a/custom_components/saj_modbus/const.py
+++ b/custom_components/saj_modbus/const.py
@@ -184,9 +184,9 @@ voltage_sensors = [
     {"name": "T-Phase Grid Voltage", "key": "TGridVolt", "icon": "sine-wave", "enable": False},
     
     {"name": "Battery 1 Voltage", "key": "Bat1Voltage", "icon": "flash", "enable": True},
-    {"name": "Battery 2 Voltage", "key": "Bat2Voltage", "icon": "flash", "enable": True},
-    {"name": "Battery 3 Voltage", "key": "Bat3Voltage", "icon": "flash", "enable": True},
-    {"name": "Battery 4 Voltage", "key": "Bat4Voltage", "icon": "flash", "enable": True},
+    {"name": "Battery 2 Voltage", "key": "Bat2Voltage", "icon": "flash", "enable": False},
+    {"name": "Battery 3 Voltage", "key": "Bat3Voltage", "icon": "flash", "enable": False},
+    {"name": "Battery 4 Voltage", "key": "Bat4Voltage", "icon": "flash", "enable": False},
     {"name": "Battery Voltage High Protection", "key": "BatProtHigh", "icon": "alert", "enable": True},
     {"name": "Battery Voltage Low Warning", "key": "BatProtLow", "icon": "alert", "enable": True},
     {"name": "Battery Charge Voltage", "key": "Bat_Chargevoltage", "icon": "battery-charging", "enable": True},
@@ -217,9 +217,9 @@ current_sensors = [
     {"name": "T-Phase Grid DC Component", "key": "TGridDCI", "icon": "current-dc", "enable": False},
     
     {"name": "Battery 1 Current", "key": "Bat1Current", "icon": "current-dc", "enable": True},
-    {"name": "Battery 2 Current", "key": "Bat2Current", "icon": "current-dc", "enable": True},
-    {"name": "Battery 3 Current", "key": "Bat3Current", "icon": "current-dc", "enable": True},
-    {"name": "Battery 4 Current", "key": "Bat4Current", "icon": "current-dc", "enable": True},
+    {"name": "Battery 2 Current", "key": "Bat2Current", "icon": "current-dc", "enable": False},
+    {"name": "Battery 3 Current", "key": "Bat3Current", "icon": "current-dc", "enable": False},
+    {"name": "Battery 4 Current", "key": "Bat4Current", "icon": "current-dc", "enable": False},
     {"name": "Battery Discharge Current Limit", "key": "BatDisCurrLimit", "icon": "battery", "enable": True},
     {"name": "Battery Charge Current Limit", "key": "BatChaCurrLimit", "icon": "battery-charging", "enable": True},
 ]
@@ -228,12 +228,12 @@ battery_sensors = [
     {"name": "Battery Energy Percent", "key": "batEnergyPercent", "icon": "battery-charging-100", "enable": True},
     {"name": "Battery 1 SOC", "key": "Bat1SOC", "icon": "battery", "enable": True},
     {"name": "Battery 1 SOH", "key": "Bat1SOH", "icon": "battery", "enable": True},
-    {"name": "Battery 2 SOC", "key": "Bat2SOC", "icon": "battery", "enable": True},
-    {"name": "Battery 2 SOH", "key": "Bat2SOH", "icon": "battery", "enable": True},
-    {"name": "Battery 3 SOC", "key": "Bat3SOC", "icon": "battery", "enable": True},
-    {"name": "Battery 3 SOH", "key": "Bat3SOH", "icon": "battery", "enable": True},
-    {"name": "Battery 4 SOC", "key": "Bat4SOC", "icon": "battery", "enable": True},
-    {"name": "Battery 4 SOH", "key": "Bat4SOH", "icon": "battery", "enable": True},
+    {"name": "Battery 2 SOC", "key": "Bat2SOC", "icon": "battery", "enable": False},
+    {"name": "Battery 2 SOH", "key": "Bat2SOH", "icon": "battery", "enable": False},
+    {"name": "Battery 3 SOC", "key": "Bat3SOC", "icon": "battery", "enable": False},
+    {"name": "Battery 3 SOH", "key": "Bat3SOH", "icon": "battery", "enable": False},
+    {"name": "Battery 4 SOC", "key": "Bat4SOC", "icon": "battery", "enable": False},
+    {"name": "Battery 4 SOH", "key": "Bat4SOH", "icon": "battery", "enable": False},
 ]
 
 
@@ -250,9 +250,9 @@ temperature_sensors = [
     {"name": "Battery Temperature", "key": "BatTemp", "icon": "battery-thermometer"},
     
     {"name": "Battery 1 Temperature", "key": "Bat1Temperature", "icon": "thermometer", "enable": True},
-    {"name": "Battery 2 Temperature", "key": "Bat2Temperature", "icon": "thermometer", "enable": True},
-    {"name": "Battery 3 Temperature", "key": "Bat3Temperature", "icon": "thermometer", "enable": True},
-    {"name": "Battery 4 Temperature", "key": "Bat4Temperature", "icon": "thermometer", "enable": True},
+    {"name": "Battery 2 Temperature", "key": "Bat2Temperature", "icon": "thermometer", "enable": False},
+    {"name": "Battery 3 Temperature", "key": "Bat3Temperature", "icon": "thermometer", "enable": False},
+    {"name": "Battery 4 Temperature", "key": "Bat4Temperature", "icon": "thermometer", "enable": False},
 ] 
 
 
@@ -294,18 +294,18 @@ information_sensors = [
     {"name": "Battery User Capacity", "key": "BatUserCap", "icon": "battery", "enable": True},
     {"name": "Battery Online", "key": "BatOnline", "icon": "cloud", "enable": True},
     {"name": "Battery 1 Cycle Count", "key": "Bat1CycleNum", "icon": "counter", "enable": True},
-    {"name": "Battery 2 Cycle Count", "key": "Bat2CycleNum", "icon": "counter", "enable": True},
-    {"name": "Battery 3 Cycle Count", "key": "Bat3CycleNum", "icon": "counter", "enable": True},
-    {"name": "Battery 4 Cycle Count", "key": "Bat4CycleNum", "icon": "counter", "enable": True},
+    {"name": "Battery 2 Cycle Count", "key": "Bat2CycleNum", "icon": "counter", "enable": False},
+    {"name": "Battery 3 Cycle Count", "key": "Bat3CycleNum", "icon": "counter", "enable": False},
+    {"name": "Battery 4 Cycle Count", "key": "Bat4CycleNum", "icon": "counter", "enable": False},
     
     {"name": "Battery 1 Fault", "key": "Bat1FaultMSG", "icon": "alert", "enable": True},
     {"name": "Battery 1 Warning", "key": "Bat1WarnMSG", "icon": "alert", "enable": True},
-    {"name": "Battery 2 Fault", "key": "Bat2FaultMSG", "icon": "alert", "enable": True},
-    {"name": "Battery 2 Warning", "key": "Bat2WarnMSG", "icon": "alert", "enable": True},
-    {"name": "Battery 3 Fault", "key": "Bat3FaultMSG", "icon": "alert", "enable": True},
-    {"name": "Battery 3 Warning", "key": "Bat3WarnMSG", "icon": "alert", "enable": True},
-    {"name": "Battery 4 Fault", "key": "Bat4FaultMSG", "icon": "alert", "enable": True},
-    {"name": "Battery 4 Warning", "key": "Bat4WarnMSG", "icon": "alert", "enable": True},
+    {"name": "Battery 2 Fault", "key": "Bat2FaultMSG", "icon": "alert", "enable": False},
+    {"name": "Battery 2 Warning", "key": "Bat2WarnMSG", "icon": "alert", "enable": False},
+    {"name": "Battery 3 Fault", "key": "Bat3FaultMSG", "icon": "alert", "enable": False},
+    {"name": "Battery 3 Warning", "key": "Bat3WarnMSG", "icon": "alert", "enable": False},
+    {"name": "Battery 4 Fault", "key": "Bat4FaultMSG", "icon": "alert", "enable": False},
+    {"name": "Battery 4 Warning", "key": "Bat4WarnMSG", "icon": "alert", "enable": False},
 ]
     
 
@@ -370,12 +370,12 @@ energy_sensors = [
 
     {"name": "Battery Pack 1 Discharge High", "key": "Bat1DischarCapH", "icon": "battery", "enable": True},
     {"name": "Battery Pack 1 Discharge Low", "key": "Bat1DischarCapL", "icon": "battery", "enable": True},
-    {"name": "Battery Pack 2 Discharge High", "key": "Bat2DischarCapH", "icon": "battery", "enable": True},
-    {"name": "Battery Pack 2 Discharge Low", "key": "Bat2DischarCapL", "icon": "battery", "enable": True},
-    {"name": "Battery Pack 3 Discharge High", "key": "Bat3DischarCapH", "icon": "battery", "enable": True},
-    {"name": "Battery Pack 3 Discharge Low", "key": "Bat3DischarCapL", "icon": "battery", "enable": True},
-    {"name": "Battery Pack 4 Discharge High", "key": "Bat4DischarCapH", "icon": "battery", "enable": True},
-    {"name": "Battery Pack 4 Discharge Low", "key": "Bat4DischarCapL", "icon": "battery", "enable": True},
+    {"name": "Battery Pack 2 Discharge High", "key": "Bat2DischarCapH", "icon": "battery", "enable": False},
+    {"name": "Battery Pack 2 Discharge Low", "key": "Bat2DischarCapL", "icon": "battery", "enable": False},
+    {"name": "Battery Pack 3 Discharge High", "key": "Bat3DischarCapH", "icon": "battery", "enable": False},
+    {"name": "Battery Pack 3 Discharge Low", "key": "Bat3DischarCapL", "icon": "battery", "enable": False},
+    {"name": "Battery Pack 4 Discharge High", "key": "Bat4DischarCapH", "icon": "battery", "enable": False},
+    {"name": "Battery Pack 4 Discharge Low", "key": "Bat4DischarCapL", "icon": "battery", "enable": False},
 
     {"name": "Today PV Energy 2", "key": "today_pv_energy2", "enable": False, "icon": "solar-power"},
     {"name": "Month PV Energy 2", "key": "month_pv_energy2", "enable": False, "icon": "solar-power"},

--- a/custom_components/saj_modbus/const.py
+++ b/custom_components/saj_modbus/const.py
@@ -368,14 +368,10 @@ energy_sensors = [
     {"name": "Backup Year Load", "key": "backup_year_load", "enable": False, "icon": "lightning-bolt"},
     {"name": "Backup Total Load", "key": "backup_total_load", "enable": False, "icon": "lightning-bolt"},
 
-    {"name": "Battery Pack 1 Discharge High", "key": "Bat1DischarCapH", "icon": "battery", "enable": True},
-    {"name": "Battery Pack 1 Discharge Low", "key": "Bat1DischarCapL", "icon": "battery", "enable": True},
-    {"name": "Battery Pack 2 Discharge High", "key": "Bat2DischarCapH", "icon": "battery", "enable": False},
-    {"name": "Battery Pack 2 Discharge Low", "key": "Bat2DischarCapL", "icon": "battery", "enable": False},
-    {"name": "Battery Pack 3 Discharge High", "key": "Bat3DischarCapH", "icon": "battery", "enable": False},
-    {"name": "Battery Pack 3 Discharge Low", "key": "Bat3DischarCapL", "icon": "battery", "enable": False},
-    {"name": "Battery Pack 4 Discharge High", "key": "Bat4DischarCapH", "icon": "battery", "enable": False},
-    {"name": "Battery Pack 4 Discharge Low", "key": "Bat4DischarCapL", "icon": "battery", "enable": False},
+    {"name": "Battery Pack 1 Discharge", "key": "Bat1DischarCap", "icon": "battery", "enable": True},
+    {"name": "Battery Pack 2 Discharge", "key": "Bat2DischarCap", "icon": "battery", "enable": False},
+    {"name": "Battery Pack 3 Discharge", "key": "Bat3DischarCap", "icon": "battery", "enable": False},
+    {"name": "Battery Pack 4 Discharge", "key": "Bat4DischarCap", "icon": "battery", "enable": False},
 
     {"name": "Today PV Energy 2", "key": "today_pv_energy2", "enable": False, "icon": "solar-power"},
     {"name": "Month PV Energy 2", "key": "month_pv_energy2", "enable": False, "icon": "solar-power"},

--- a/custom_components/saj_modbus/modbus_readers.py
+++ b/custom_components/saj_modbus/modbus_readers.py
@@ -246,8 +246,7 @@ async def read_battery_data(client: ModbusClient) -> DataDict:
         ("Bat3Current", "16i"), ("Bat3Temperature", "16i", 0.1), ("Bat3CycleNum", None, 1),
         ("Bat4SOC", None), ("Bat4SOH", None), ("Bat4Voltage", None, 0.1), ("Bat4Current", "16i"),
         ("Bat4Temperature", "16i", 0.1), ("Bat4CycleNum", None, 1), (None, "skip_bytes", 12),
-        ("Bat1DischarCapH", None, 1), ("Bat1DischarCapL", None, 1), ("Bat2DischarCapH", None, 1), ("Bat2DischarCapL", None, 1),
-        ("Bat3DischarCapH", None, 1), ("Bat3DischarCapL", None, 1), ("Bat4DischarCapH", None, 1), ("Bat4DischarCapL", None, 1),
+        ("Bat1DischarCap", "32u", 1), ("Bat2DischarCap", "32u", 1), ("Bat3DischarCap", "32u", 1), ("Bat4DischarCap", "32u", 1),
         ("BatProtHigh", None, 0.1), ("BatProtLow", None, 0.1), ("Bat_Chargevoltage", None, 0.1), ("Bat_DisCutOffVolt", None, 0.1),
         ("BatDisCurrLimit", None, 0.1), ("BatChaCurrLimit", None, 0.1),
     ]


### PR DESCRIPTION
Registers for "Battery (Pack) {2|3|4} {Voltage|Current|SOC|SOH|Temperature|Fault|Warning|Discharge}" should be disabled by default, as setups with external batteries are rare.

Registers A02AH-A031H, 41002-41009 (Bat#DischarCap{H|L}) are combined to a 32bit value each