### PR TITLE
add reading registers needed for passive mode, all disabled by default

### DIFF
--- a/custom_components/saj_modbus/const.py
+++ b/custom_components/saj_modbus/const.py
@@ -107,7 +107,6 @@ frequency_sensors_group = SensorGroup(
     icon="mdi:sine-wave"  # Passendes Icon für Frequenz
 )
 
-
 # Neue Gruppe für Zeit- bzw. Scheduling-Daten
 schedule_sensors_group = SensorGroup(
     unit_of_measurement=None,
@@ -306,6 +305,23 @@ information_sensors = [
     {"name": "Battery 3 Warning", "key": "Bat3WarnMSG", "icon": "alert", "enable": True},
     {"name": "Battery 4 Fault", "key": "Bat4FaultMSG", "icon": "alert", "enable": True},
     {"name": "Battery 4 Warning", "key": "Bat4WarnMSG", "icon": "alert", "enable": True},
+
+    {"name": "Passive Charge Enable", "key": "PassiveChargeEnable", "icon": "information-outline", "enable": False},
+    {"name": "Passive GridChargePower", "key": "PassiveGridChargePower", "icon": "information-outline", "enable": False},
+    {"name": "Passive GridDisChargePower", "key": "PassiveGridDischargePower", "icon": "information-outline", "enable": False},
+    {"name": "Passive BatteryChargePower", "key": "PassiveBatChargePower", "icon": "information-outline", "enable": False},
+    {"name": "Passive BatteryDisChargePower", "key": "PassiveBatDisChargePower", "icon": "information-outline", "enable": False},
+    {"name": "Battery OnGridDisDepth", "key": "BatOnGridDisDepth", "icon": "information-outline", "enable": False},
+    {"name": "Battery OffGridDisChargeDepth", "key": "BatOffGridDisDepth", "icon": "information-outline", "enable": False},
+    {"name": "Battery ChargeDepth", "key": "BatChargeDepth", "icon": "information-outline", "enable": False},
+    {"name": "Battery Charge Power Limit", "key": "BatChargePower", "icon": "information-outline", "enable": False},
+    {"name": "Battery Discharge Power Limit", "key": "BatDischargePower", "icon": "information-outline", "enable": False},
+    {"name": "Grid max Charge Power", "key": "GridChargePower", "icon": "information-outline", "enable": False},
+    {"name": "Grid max Discharge Power", "key": "GridDischargePower", "icon": "information-outline", "enable": False},
+    {"name": "Undoc 8300 AppMode", "key": "undoc8300appmode", "icon": "information-outline", "enable": False},
+    {"name": "Undoc 8302 ChargePower", "key": "undoc8302chargepower", "icon": "information-outline", "enable": False},
+    {"name": "Undoc 8303 ChargePower", "key": "undoc8303chargepower", "icon": "information-outline", "enable": False},
+
 ]
     
 

--- a/custom_components/saj_modbus/hub.py
+++ b/custom_components/saj_modbus/hub.py
@@ -117,6 +117,8 @@ class SAJModbusHub(DataUpdateCoordinator[Dict[str, Any]]):
                 modbus_readers.read_additional_modbus_data_2_part_2,
                 modbus_readers.read_additional_modbus_data_3,
                 modbus_readers.read_additional_modbus_data_4,
+                modbus_readers.read_charging_modbus_data_1,
+                modbus_readers.read_charging_modbus_data_2,
                 modbus_readers.read_battery_data,
                 modbus_readers.read_first_charge_data,
             ]

--- a/custom_components/saj_modbus/modbus_readers.py
+++ b/custom_components/saj_modbus/modbus_readers.py
@@ -233,6 +233,38 @@ async def read_additional_modbus_data_4(client: ModbusClient) -> DataDict:
     
     return await _read_modbus_data(client, 16433, 21, decode_instructions, "grid_phase_data", default_factor=0.001)
 
+async def read_charging_modbus_data_1(self) -> Dict[str, Any]:
+    """Reads charging-related data (Set 1)."""
+    decode_instructions = [
+        ("PassiveChargeEnable", "16u"),      
+        ("PassiveGridChargePower", "16u", 0.001),               
+        ("PassiveGridDischargePower", "16u", 0.001),               
+        ("PassiveBatChargePower", "16u", 0.001),               
+        ("PassBatDisChargePower", "16u", 0.001),               
+        (None, "skip_bytes", 18),                  
+        ("BatOnGridDisDepth", "16u"),               
+        ("BatOffGridDisDepth", "16u"),               
+        ("BatChargeDepth", "16u"),               
+        (None, "skip_bytes", 12),                  
+        ("BatChargePower", "16u", 0.001),               
+        ("BatDischargePower", "16u", 0.001),               
+        ("GridChargePower", "16u", 0.001),               
+        ("GridDischargePower", "16u", 0.001),               
+    ]
+
+    return await _read_modbus_data(client, 13878, 27, decode_instructions, "charging_data_1", default_factor=1)
+
+async def read_charging_modbus_data_2(self) -> Dict[str, Any]:
+    """Reads charging-related data (Set 2)."""
+    decode_instructions_charging_part_2 = [
+        ("undoc8300appmode", "16u"),      
+        (None, "skip_bytes", 2),                  
+        ("undoc8302chargepower", "16u"),      
+        ("undoc8303chargepower", "16u"),      
+    ]
+
+    return await _read_modbus_data(client, 33536, 4, decode_instructions, "charging_data_2", default_factor=1)
+
 async def read_battery_data(client: ModbusClient) -> DataDict:
     """Reads battery data from registers 40960 to 41015."""
     decode_instructions = [


### PR DESCRIPTION
Add 12 registers from the official modbus register list, dealing with AppMode=3 (passive).

Add further 3 undocumented registers from observation (0x8300 ff.), which are used by kiwigrid's VoyagerX/Energiekonzepte Deutschland's Ampere.IQ for their grid load stearing.

All registers are didabled by default.