### PR TITLE
Passive charging

### DIFF
--- a/.github/ISSUE_TEMPLATE/modbus_support.yaml
+++ b/.github/ISSUE_TEMPLATE/modbus_support.yaml
@@ -97,11 +97,11 @@ body:
     attributes:
       label: Pre-checks
       options:
-        - label: I have updated to the latest release
-          required: true
         - label: I confirmed the inverter is reachable via Modbus TCP
           required: true
         - label: I searched for existing issues
+          required: true
+        - label: I removed the integration and performed a clean reinstallation.
           required: true
 
   - type: markdown

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog (v2.6.0)
 
-### 🚀 New Passive Input Methods Added
+### 🚀 New Passive Charge/Discharging Input Methods Added 
 
-* **New Passive Charging/Discharging Input Registers:**
+* **New Input Registers:**
 
   - `SAJ Passive Charge Enable (Input)` - Register 3636H ...
   - `SAJ Passive Grid Charge Power (Input)` 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
   
 
 * These new input methods allow for precise control of passive battery charge & discharge power.
-see Discussion F&Q > Link
+see Discussion https://github.com/stanus74/home-assistant-saj-h2-modbus/discussions/105
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,27 +1,33 @@
-# Changelog (v2.5.1)
+# Changelog (v2.6.0)
 
-### Added
+### 🚀 New Passive Input Methods Added
 
-* **New Sensor `CT Grid Power Total`**
+* **New Passive Charging/Discharging Input Registers:**
 
-  * Aggregates real power from all three smart meter phases:
+  - `SAJ Passive Charge Enable (Input)` - Register 3636H ...
+  - `SAJ Passive Grid Charge Power (Input)` 
+  - `SAJ Passive Grid Discharge Power (Input)`
+  - `SAJ Passive Battery Charge Power (Input)` 
+  - `SAJ Passive Battery Discharge Power (Input)` - ... Register 363AH
+  
 
-    * `Meter_A_PowerW` (Phase R)
-    * `Meter_A_PowerW_2` (Phase S)
-    * `Meter_A_PowerW_3` (Phase T)
-  * Calculated automatically in `read_meter_a_data` and exposed as `sensor.saj_ct_gridpower_total`.
-  * Provides the total grid power directly from the smart meter (instead of relying on inverter-internal estimates).
+* These new input methods allow for precise control of passive battery charge & discharge power.
+see Discussion F&Q > Link
 
-### Removed
+---
 
-* **Obsolete CT Sensors** (no backing registers):
+### 🚀 New Fast Sensors Added
 
-  * `CT_GridPowerWatt`
-  * `CT_PVPowerWatt`
-  * `CT_GridPowerVA`
-  * `CT_PVPowerVA`
-    → These were placeholders without real Modbus registers and are now fully removed for data consistency.
+* **Fast Coordinator (10s) now includes additional sensors:**
 
+  - `sensor.saj_ct_pv_power_watt`
+  - `sensor.saj_ct_pv_power_va`
+  - `sensor.saj_ct_grid_power_va`
+  - `sensor.saj_ct_grid_power_watt`  
+
+* These sensors are now updated every 10 seconds via the Fast Coordinator, ensuring more frequent updates for live data monitoring.
+
+---
 
 # Changelog (v2.5.0)
 

--- a/custom_components/saj_h2_modbus/charge_control.py
+++ b/custom_components/saj_h2_modbus/charge_control.py
@@ -28,6 +28,11 @@ PENDING_FIELDS: List[tuple[str, str]] = (
         ("battery_discharge_power_limit", "battery_discharge_power_limit"),
         ("grid_max_charge_power", "grid_max_charge_power"),
         ("grid_max_discharge_power", "grid_max_discharge_power"),
+        ("passive_charge_enable", "passive_charge_enable"),
+        ("passive_grid_charge_power", "passive_grid_charge_power"),
+        ("passive_grid_discharge_power", "passive_grid_discharge_power"),
+        ("passive_bat_charge_power", "passive_bat_charge_power"),
+        ("passive_bat_discharge_power", "passive_bat_discharge_power"),
     ]
 )
 
@@ -61,6 +66,11 @@ REGISTERS = {
     "grid_max_charge_power": 0x364F,
     "grid_max_discharge_power": 0x3650,
     "discharge_time_enable": 0x3651,
+    "passive_charge_enable": 0x3636,
+    "passive_grid_charge_power": 0x3637,
+    "passive_grid_discharge_power": 0x3638,
+    "passive_bat_charge_power": 0x3639,
+    "passive_bat_discharge_power": 0x363A,
 }
 
 # Mapping of simple pending attributes to their register addresses and labels
@@ -98,6 +108,26 @@ SIMPLE_REGISTER_MAP: Dict[str, Tuple[int, str]] = {
     "grid_max_discharge_power": (
         REGISTERS["grid_max_discharge_power"],
         "grid max discharge power",
+    ),
+    "passive_charge_enable": (
+        REGISTERS["passive_charge_enable"],
+        "passive charge enable",
+    ),
+    "passive_grid_charge_power": (
+        REGISTERS["passive_grid_charge_power"],
+        "passive grid charge power",
+    ),
+    "passive_grid_discharge_power": (
+        REGISTERS["passive_grid_discharge_power"],
+        "passive grid discharge power",
+    ),
+    "passive_bat_charge_power": (
+        REGISTERS["passive_bat_charge_power"],
+        "passive battery charge power",
+    ),
+    "passive_bat_discharge_power": (
+        REGISTERS["passive_bat_discharge_power"],
+        "passive battery discharge power",
     ),
 }
 

--- a/custom_components/saj_h2_modbus/const.py
+++ b/custom_components/saj_h2_modbus/const.py
@@ -59,6 +59,7 @@ apparent_power_sensors_group = SensorGroup(
     device_class=SensorDeviceClass.APPARENT_POWER,
     state_class=SensorStateClass.MEASUREMENT,
     icon="mdi:flash-outline",
+    force_update=True
 )
 
 voltage_sensors_group = SensorGroup(
@@ -186,6 +187,9 @@ power_sensors = [
     {"name": "PV3 Power", "key": "pv3Power", "icon": "flash", "enable": False},
     {"name": "PV4 Power", "key": "pv4Power", "icon": "flash", "enable": False},
 
+    {"name": "CT Grid Power Watt", "key": "CT_GridPowerWatt", "icon": "flash", "enable": False},
+    {"name": "CT PV Power Watt", "key": "CT_PVPowerWatt", "icon": "flash", "enable": False},
+
   
     {"name": "Backup Total Load Power Watt", "key": "BackupTotalLoadPowerWatt", "icon": "home-lightning-bolt", "enable": False},
     {"name": "R-Phase Grid Power Watt", "key": "RGridPowerWatt", "icon": "flash", "enable": False},
@@ -208,6 +212,9 @@ power_sensors = [
 
 apparent_power_sensors = [
     
+    {"name": "CT Grid Power VA", "key": "CT_GridPowerVA", "enable": False},
+    {"name": "CT PV Power VA", "key": "CT_PVPowerVA", "enable": False},
+
     {"name": "Total Inverter Power VA", "key": "TotalInvPowerVA", "enable": False},
     {"name": "Backup Total Load Power VA", "key": "BackupTotalLoadPowerVA", "enable": False},
     {"name": "R-Phase Grid Power VA", "key": "RGridPowerVA", "enable": False},

--- a/custom_components/saj_h2_modbus/const.py
+++ b/custom_components/saj_h2_modbus/const.py
@@ -505,11 +505,11 @@ battery_schedule_sensors = [
     {"name": "Discharge 7 End Time", "key": "discharge7_end_time", "icon": "clock-outline"},
     {"name": "Discharge 7 Day Mask", "key": "discharge7_day_mask", "icon": "calendar"},
     {"name": "Discharge 7 Power Percent", "key": "discharge7_power_percent", "icon": "flash", "unit_of_measurement": "%"},
-    {"name": "Passive Charge Enable", "key": "Passive_charge_enable", "icon": "power-settings"},
-    {"name": "Passive Grid Charge Power", "key": "Passive_GridChargePower", "icon": "transmission-tower", "unit_of_measurement": "%"},
-    {"name": "Passive Grid Discharge Power", "key": "Passive_GridDisChargePower", "icon": "transmission-tower", "unit_of_measurement": "%"},
-    {"name": "Passive Battery Charge Power", "key": "Passive_BatChargePower", "icon": "battery-charging", "unit_of_measurement": "%"},
-    {"name": "Passive Battery Discharge Power", "key": "Passive_BatDisChargePower", "icon": "battery", "unit_of_measurement": "%"},
+    {"name": "Passive Charge Enable", "key": "passive_charge_enable", "icon": "power-settings"},
+    {"name": "Passive Grid Charge Power", "key": "passive_grid_charge_power", "icon": "transmission-tower", "unit_of_measurement": "%"},
+    {"name": "Passive Grid Discharge Power", "key": "passive_grid_discharge_power", "icon": "transmission-tower", "unit_of_measurement": "%"},
+    {"name": "Passive Battery Charge Power", "key": "passive_bat_charge_power", "icon": "battery-charging", "unit_of_measurement": "%"},
+    {"name": "Passive Battery Discharge Power", "key": "passive_bat_discharge_power", "icon": "battery", "unit_of_measurement": "%"},
 ]
 
 anti_reflux_sensors = [

--- a/custom_components/saj_h2_modbus/hub.py
+++ b/custom_components/saj_h2_modbus/hub.py
@@ -24,7 +24,7 @@ from .charge_control import ChargeSettingHandler, PENDING_FIELDS, make_pending_s
 _LOGGER = logging.getLogger(__name__)
 
 # Global switch: Fast-Coordinator (10s) active by default?
-FAST_POLL_DEFAULT = True # True or False
+FAST_POLL_DEFAULT = False # True or False
 
 
 class SAJModbusHub(DataUpdateCoordinator[Dict[str, Any]]):
@@ -87,6 +87,11 @@ class SAJModbusHub(DataUpdateCoordinator[Dict[str, Any]]):
         self._pending_battery_discharge_power_limit: Optional[int] = None
         self._pending_grid_max_charge_power: Optional[int] = None
         self._pending_grid_max_discharge_power: Optional[int] = None
+        self._pending_passive_charge_enable: Optional[int] = None
+        self._pending_passive_grid_charge_power: Optional[int] = None
+        self._pending_passive_grid_discharge_power: Optional[int] = None
+        self._pending_passive_bat_charge_power: Optional[int] = None
+        self._pending_passive_bat_discharge_power: Optional[int] = None
 
         self._setting_handler = ChargeSettingHandler(self)
 
@@ -259,6 +264,11 @@ class SAJModbusHub(DataUpdateCoordinator[Dict[str, Any]]):
                 (self._pending_battery_discharge_power_limit is not None, self._setting_handler.handle_battery_discharge_power_limit),
                 (self._pending_grid_max_charge_power is not None, self._setting_handler.handle_grid_max_charge_power),
                 (self._pending_grid_max_discharge_power is not None, self._setting_handler.handle_grid_max_discharge_power),
+                (self._pending_passive_charge_enable is not None, self._setting_handler.handle_passive_charge_enable),
+                (self._pending_passive_grid_charge_power is not None, self._setting_handler.handle_passive_grid_charge_power),
+                (self._pending_passive_grid_discharge_power is not None, self._setting_handler.handle_passive_grid_discharge_power),
+                (self._pending_passive_bat_charge_power is not None, self._setting_handler.handle_passive_bat_charge_power),
+                (self._pending_passive_bat_discharge_power is not None, self._setting_handler.handle_passive_bat_discharge_power),
             ]
             # Dynamically add generic discharge handlers (slots 1..7)
             for i in range(1, 8):

--- a/custom_components/saj_h2_modbus/manifest.json
+++ b/custom_components/saj_h2_modbus/manifest.json
@@ -9,6 +9,6 @@
   "issue_tracker": "https://github.com/stanus74/home-assistant-saj-h2-modbus/issues",
   "requirements": ["pymodbus>=3.6.9"],
 
-  "version": "2.5.0"
+  "version": "2.6.0"
 
 }

--- a/custom_components/saj_h2_modbus/modbus_readers.py
+++ b/custom_components/saj_h2_modbus/modbus_readers.py
@@ -436,11 +436,15 @@ async def read_anti_reflux_data(client: ModbusClient, lock: Lock) -> DataDict:
 async def read_passive_battery_data(client: ModbusClient, lock: Lock) -> DataDict:
     """Reads the Passive Charge/Discharge and Battery configuration registers."""
     decode_instructions = [
-        ("Passive_charge_enable", "16u", 1),
-        ("Passive_GridChargePower", "16u"),
-        ("Passive_GridDisChargePower", "16u"),
-        ("Passive_BatChargePower", "16u"),
-        ("Passive_BatDisChargePower", "16u"),
+        
+         # New passive registers in snake_case
+        ("passive_charge_enable", "16u", 1),
+        ("passive_grid_charge_power", "16u"),
+        ("passive_grid_discharge_power", "16u"),
+        ("passive_bat_charge_power", "16u"),
+        ("passive_bat_discharge_power", "16u"),
+
+
         (None, "skip_bytes", 18),  # Skip registers 363B-3643
         ("BatOnGridDisDepth", "16u", 1),
         ("BatOffGridDisDepth", "16u", 1),
@@ -455,6 +459,7 @@ async def read_passive_battery_data(client: ModbusClient, lock: Lock) -> DataDic
 
     try:
         data = await _read_modbus_data(client, lock, 0x3636, 27, decode_instructions, "passive_battery_data", default_factor=0.1)
+        _LOGGER.debug(f"Passive Battery Data: {data}")  # Add this line
         return data
     except Exception as e:
         _LOGGER.error(f"Error reading Passive Battery data: {e}")

--- a/custom_components/saj_h2_modbus/modbus_readers.py
+++ b/custom_components/saj_h2_modbus/modbus_readers.py
@@ -161,33 +161,19 @@ async def read_additional_modbus_data_1_part_1(client: ModbusClient, lock: Lock)
 async def read_additional_modbus_data_1_part_2(client: ModbusClient, lock: Lock) -> DataDict:
     """Reads the second part of additional operating data (Set 1)."""
     decode_instructions_part_2 = [
-        ("directionPV", "16u"),              # 0x4095  (PV_direction)
-        ("directionBattery", "16i"),         # 0x4096  (Battery_direction)
-        ("directionGrid", "16i"),            # 0x4097  (Grid_direction)
-        ("directionOutput", "16u"),          # 0x4098  (Output_direction)
-
-        (None, "skip_bytes", 14),            # -> springt auf 0x40A0
-        ("TotalLoadPower", "16i"),           # 0x40A0  (SysTotalLoadWatt)
-
-        (None, "skip_bytes", 8),             # 0x40A1–0x40A4 überspringen
-        ("pvPower", "16i"),                  # 0x40A5  (TotalPVPower)
-        ("batteryPower", "16i"),             # 0x40A6  (TotalBatteryPower)
-        ("totalgridPower", "16i"),           # 0x40A7  (TotalGridPowerWatt)
-        ("totalgridPowerVA", "16i"),         # 0x40A8  (TotalGridPowerVA)
-        ("inverterPower", "16i"),            # 0x40A9  (TotalInvPowerWatt)
-        ("TotalInvPowerVA", "16i"),          # 0x40AA  (TotalInvPowerVA)
-        ("BackupTotalLoadPowerWatt", "16u"), # 0x40AB  (BackupTotalLoadWatt)
-        ("BackupTotalLoadPowerVA", "16u"),   # 0x40AC  (BackupTotalLoadVA)
-        ("gridPower", "16i"),                # 0x40AD  (SysGridPowerWatt)
+        ("directionPV", None), ("directionBattery", "16i"), ("directionGrid", "16i"),
+        ("directionOutput", None), (None, "skip_bytes", 14), ("TotalLoadPower", "16i"),
+        ("CT_GridPowerWatt", "16i"), ("CT_GridPowerVA", "16i"),
+        ("CT_PVPowerWatt", "16i"), ("CT_PVPowerVA", "16i"),
+        ("pvPower", "16i"), ("batteryPower", "16i"),
+        ("totalgridPower", "16i"), ("totalgridPowerVA", "16i"),
+        ("inverterPower", "16i"), ("TotalInvPowerVA", "16i"),
+        ("BackupTotalLoadPowerWatt", None), ("BackupTotalLoadPowerVA", None),
+        ("gridPower", "16i"),
     ]
+    
+    return await _read_modbus_data(client, lock, 16533, 25, decode_instructions_part_2, 'additional_data_1_part_2', default_factor=1)
 
-    return await _read_modbus_data(
-        client, lock,
-        16533, 25,   # 16533 dez = 0x4095 hex
-        decode_instructions_part_2,
-        'additional_data_1_part_2',
-        default_factor=1
-    )
 
 async def read_additional_modbus_data_2_part_1(client: ModbusClient, lock: Lock) -> DataDict:
     """Reads the first part of additional operating data (Set 2)."""

--- a/custom_components/saj_h2_modbus/number.py
+++ b/custom_components/saj_h2_modbus/number.py
@@ -59,6 +59,11 @@ async def async_setup_entry(hass, entry, async_add_entities):
         SajGenericNumberEntity(hub, "SAJ Battery Discharge Power Limit (Input)", f"{hub.name}_battery_discharge_power_limit_input", 0, 1100, 100, 1100, device_info, set_method_name="set_battery_discharge_power_limit"),
         SajGenericNumberEntity(hub, "SAJ Grid Max Charge Power (Input)", f"{hub.name}_grid_max_charge_power_input", 0, 1100, 100, 1100, device_info, set_method_name="set_grid_max_charge_power"),
         SajGenericNumberEntity(hub, "SAJ Grid Max Discharge Power (Input)", f"{hub.name}_grid_max_discharge_power_input", 0, 1100, 100, 1100, device_info, set_method_name="set_grid_max_discharge_power"),
+        SajGenericNumberEntity(hub, "SAJ Passive Charge Enable (Input)", f"{hub.name}_passive_charge_enable_input", 0, 2, 1, 0, device_info, set_method_name="set_passive_charge_enable"),
+        SajGenericNumberEntity(hub, "SAJ Passive Grid Charge Power (Input)", f"{hub.name}_passive_grid_charge_power_input", 0, 1100, 100, 0, device_info, set_method_name="set_passive_grid_charge_power"),
+        SajGenericNumberEntity(hub, "SAJ Passive Grid Discharge Power (Input)", f"{hub.name}_passive_grid_discharge_power_input", 0, 1100, 100, 0, device_info, set_method_name="set_passive_grid_discharge_power"),
+        SajGenericNumberEntity(hub, "SAJ Passive Battery Charge Power (Input)", f"{hub.name}_passive_bat_charge_power_input", 0, 1100, 100, 0, device_info, set_method_name="set_passive_bat_charge_power"),
+        SajGenericNumberEntity(hub, "SAJ Passive Battery Discharge Power (Input)", f"{hub.name}_passive_bat_discharge_power_input", 0, 1100, 100, 0, device_info, set_method_name="set_passive_bat_discharge_power"),
     ]
 
     for i in range(1, 8):

--- a/custom_components/saj_h2_modbus/sensor.py
+++ b/custom_components/saj_h2_modbus/sensor.py
@@ -15,6 +15,10 @@ _LOGGER = logging.getLogger(__name__)
 FAST_UPDATE_SENSOR_KEYS = [
     "TotalLoadPower", "pvPower", "batteryPower", "totalgridPower",
     "inverterPower", "gridPower",
+    "directionPV", "directionBattery", "directionGrid", "directionOutput",
+    "CT_GridPowerWatt", "CT_GridPowerVA", "CT_PVPowerWatt", "CT_PVPowerVA",
+    "totalgridPowerVA", "TotalInvPowerVA", "BackupTotalLoadPowerWatt",
+    "BackupTotalLoadPowerVA",
 ]
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback) -> None:


### PR DESCRIPTION
### 🚀 New Passive Input Registers

Added 5 new Modbus input registers for controlling passive charging/discharging (Registers **3636H–363AH**).
See details in [[Discussion #105](https://github.com/stanus74/home-assistant-saj-h2-modbus/discussions/105)](https://github.com/stanus74/home-assistant-saj-h2-modbus/discussions/105).

---

### ⚡ Fast Sensors Update

The **Fast Coordinator (10s)** now also updates:

* `sensor.saj_ct_pv_power_watt`
* `sensor.saj_ct_pv_power_va`
* `sensor.saj_ct_grid_power_va`
* `sensor.saj_ct_grid_power_watt`
