### PR TITLE
Add _fast_coordinator attribute to hub class

### DIFF
--- a/custom_components/saj_h2_modbus/hub.py
+++ b/custom_components/saj_h2_modbus/hub.py
@@ -92,6 +92,7 @@ class SAJModbusHub(DataUpdateCoordinator[Dict[str, Any]]):
         self._connection_lock = asyncio.Lock()
         self.updating_settings = False
         self.fast_enabled: bool = FAST_POLL_DEFAULT if fast_enabled is None else fast_enabled
+        self._fast_coordinator = None
 
         self._reconnecting = False
         self._max_retries = 2


### PR DESCRIPTION
If not set to None it fails on line 240 with no attribute error.